### PR TITLE
Fixed trailing whitespace causing eslint error and added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# Get an EditorConfig plugin for your text editor:
+# https://editorconfig.org/#download
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+[*.json]
+indent_style = space
+indent_size = 2
+charset = utf-8
+
+[*.vue]
+indent_style = space
+indent_size = 2
+charset = utf-8
+
+[*.md]
+indent_size = 4

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,29 +1,29 @@
 module.exports = {
-	root: true,
-	env: {
-	  browser: true,
-	  node: true
-	},
-	parserOptions: {
-	  parser: 'babel-eslint'
-	},
-	extends: [
-	  "eslint:recommended",
-	  // https://github.com/vuejs/eslint-plugin-vue#priority-a-essential-error-prevention
-	  // consider switching to `plugin:vue/strongly-recommended` or `plugin:vue/recommended` for stricter rules.
-	  "plugin:vue/recommended",
-	  "plugin:prettier/recommended"
-	],
-	// required to lint *.vue files
-	plugins: [
-	  'vue'
-	],
-	// add your custom rules here
-	rules: {
-		"vue/html-indent": ["error", 2],
-	  "semi": [2, "never"],
-		"no-console": "off",
-	  "vue/max-attributes-per-line": "off",
-	  "prettier/prettier": ["error", { "semi": false, "tabWidth": 4 }]
-	}
-  }
+    root: true,
+    env: {
+        browser: true,
+        node: true
+    },
+    parserOptions: {
+        parser: 'babel-eslint'
+    },
+    extends: [
+        "eslint:recommended",
+        // https://github.com/vuejs/eslint-plugin-vue#priority-a-essential-error-prevention
+        // consider switching to `plugin:vue/strongly-recommended` or `plugin:vue/recommended` for stricter rules.
+        "plugin:vue/recommended",
+        "plugin:prettier/recommended"
+    ],
+    // required to lint *.vue files
+    plugins: [
+        'vue'
+    ],
+    // add your custom rules here
+    rules: {
+        "vue/html-indent": ["error", 2],
+        "semi": [2, "never"],
+        "no-console": "off",
+        "vue/max-attributes-per-line": "off",
+        "prettier/prettier": ["error", { "semi": false, "tabWidth": 4 }]
+    }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -56,7 +56,7 @@ module.exports = {
     /*
     ** Mode Configuration
     */
-    mode: "spa",  
+    mode: "spa",
     /*
     ** Build configuration
     */


### PR DESCRIPTION
Looks like builds were failing due to a linting error. I added `.editconfig` with the remove trailing space flag set. I also set some reasonable defaults based on the indentation I saw in the existing files. 