### PR TITLE
swapped bootstrap for vue-bootstrap

### DIFF
--- a/assets/scss/hack.scss
+++ b/assets/scss/hack.scss
@@ -4,7 +4,8 @@
 @import "./functions";
 
 /* 3rd party imports. */
-@import "~bootstrap/scss/bootstrap";
+@import '~bootstrap/scss/bootstrap.scss';
+@import '~bootstrap-vue/src/index.scss';
 @import "~hamburgers/_sass/hamburgers/hamburgers";
 
 /* H4C styles. */

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     css: ["~/assets/scss/hack.scss", "swiper/dist/css/swiper.css"],
-    modules: [["@nuxtjs/style-resources"]],
+    modules: ["@nuxtjs/style-resources", "bootstrap-vue/nuxt"],
     styleResources: {
         sass: "./assets/scss/*.scss"
     },
@@ -81,7 +81,7 @@ module.exports = {
     },
     watchers: {
         webpack: {
-            aggregateTimeout:300,
+            aggregateTimeout: 300,
             poll: 1000
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hackforacause-website",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2218,8 +2218,19 @@
     "bootstrap": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==",
-      "dev": true
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+    },
+    "bootstrap-vue": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.4.tgz",
+      "integrity": "sha512-/5WXa3ir5uajcs7ze7jz7QXpYuJGWHjvJ8biMq0+e0IIIxw2jSdh4LsiFKD7C7qtgKre28hhXOfx79RmZX4wcQ==",
+      "requires": {
+        "@nuxt/opencollective": "^0.3.0",
+        "bootstrap": ">=4.3.1 <5.0.0",
+        "popper.js": "^1.15.0",
+        "portal-vue": "^2.1.6",
+        "vue-functional-data-merge": "^3.1.0"
+      }
     },
     "boxen": {
       "version": "4.1.0",
@@ -7340,6 +7351,16 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
+    "popper.js": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
+    },
+    "portal-vue": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.6.tgz",
+      "integrity": "sha512-lvCF85D4e8whd0nN32D8FqKwwkk7nYUI3Ku8UAEx4Z1reomu75dv5evRUTZNaj1EalxxWNXiNl0EHRq36fG8WA=="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -10665,6 +10686,11 @@
           "dev": true
         }
       }
+    },
+    "vue-functional-data-merge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
+      "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "pushlive": "npm run generate && npm run deploy"
   },
   "dependencies": {
+    "bootstrap-vue": "^2.0.4",
     "nuxt": "^2.10.0",
     "vue-awesome-swiper": "^3.1.3"
   },
   "devDependencies": {
     "@nuxtjs/style-resources": "^1.0.0",
     "babel-eslint": "^8.2.2",
-    "bootstrap": "^4.0.0",
     "cross-env": "^5.1.4",
     "eslint": "^4.18.2",
     "eslint-friendly-formatter": "^3.0.0",


### PR DESCRIPTION
Removed Bootstrap 4 package and replaces with BootstrapVue v2.0.4 (Vue.js v2.6 / Bootstrap SCSS v4.3) with Nuxt.js support.

Replaced/modified references to old bootstrap in config files and in SCSS files.

Tested on MacOS/Chrome.

For https://github.com/csjoblom/hackforacause-website/issues/109