### PR TITLE
Updating site to reflect cancellation

### DIFF
--- a/components/HackNav.vue
+++ b/components/HackNav.vue
@@ -37,9 +37,8 @@
         <li class="nav-item">
           <a id="h4c-participate"
              class="nav-link"
-             href=""
+             href="/cancellation-policy"
              title="Sign up for Hack for a Cause 2020"
-             target="_blank"
           >Sign up!</a>
         </li>
         -->
@@ -73,11 +72,6 @@ export default {
                 to: "/",
                 label: "Home",
                 title: "Hack for a Cause Home"
-            },
-            {
-                to: "/schedule",
-                label: "SCHEDULE",
-                title: "Hack for a Cause Schedule"
             },
             {
                 to: "/challenges-2020",

--- a/pages/cancellation-policy/index.vue
+++ b/pages/cancellation-policy/index.vue
@@ -1,0 +1,45 @@
+<template>
+  <main id="h4c-faq-main" role="main">
+    <section>
+      <hack-header header-class="h4c-header--main">
+        <div class="row align-items-center">
+          <div class="col text-center">
+            <h1 class="h4c--title d-inline">
+              Cancellation Information and Policies
+            </h1>
+          </div>
+        </div>
+      </hack-header>
+    </section>
+    <section id="h4c-faq" class="container">
+      <p>Out of an abundance of concern for you, your families and our community, TAO is going to postpone April's Hack 4 a Cause to be held April 3-5 at Nulia. We encourage everyone to take social distancing seriously and take the necessary precautions for the health and wellness of all.</p>
+      <p>We believe in this event and its impact on the community. We also know that this is an important event for students and employers as well as our non-profit partners. We will be rescheduling this event so stay tuned for a new date with the same challenges!</p>
+      <p>In the meantime, we will be offering full refunds of both registration and t-shirts. We will get out a communication out soon regarding the new dates. In the meantime, please be safe and well and we appreciate your continued support.</p>
+      <p>Warmly,<br>Cara Snow, Technology Association of Oregon<br>and the H4AC Steering Commitee</p>
+    </section>
+    <hack-footer />
+  </main>
+</template>
+
+<script>
+import HackHeader from "~/components/HackHeader"
+import HackFooter from "@/components/Footer"
+export default {
+    components: {
+        HackHeader,
+        HackFooter
+    }
+}
+</script>
+
+<style lang="scss">
+#h4c-faq {
+    margin-bottom: 5rem;
+}
+#h4c-header > .row {
+    height: 100% !important;
+}
+.h4c--title {
+    font-size: 45px;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,13 @@
 <template>
   <main role="main">
+    <section
+      id="sponsor-hack-for-a-cause"
+      class="h4c-bg--primary py-5 text-center"
+    >
+      <p class="lead container py-5">
+        NOTICE: The 2020 Hack for a Cause event has been postponed and will no longer take place in April.<br>Please check <a href="/cancellation-policy">the cancellation page</a> for more information.
+      </p>
+    </section>
     <section>
       <hack-header header-class="h4c-header--main">
         <div id="h4c-header" class="flexcol">
@@ -25,13 +33,13 @@
             </div>
           </div>
           <div id="h4c-dates" class="h4c-info__heading">
-            <strong>APRIL 3-5, 2020</strong>
+            <strong>DATE TBA</strong>
           </div>
           <div
             id="h4c-location"
             class="h4c-info__heading text-center"
           >
-            <small>NEW LOCATION FOR 2020!</small>
+            <small>LOCATION TBA</small>
           </div>
           <div id="h4c-description" class="h4c-info__heading">
             <strong>Philanthropic Hackathon</strong>
@@ -48,15 +56,14 @@
           <div class="flexrow h4c--cta">
             <div id="h4c-button">
               <a class="button"
-                 target="_blank"
-                 href="https://web.cvent.com/event/ea75cec7-7a52-4eb8-8da2-9f89566b44c0/summary"
+                 href="/cancellation-policy"
                  title="Sign up for Hack for a Cause 2020">
                 Register for Event
               </a>
             </div>
             <div id="h4c-button">
               <a class="button"
-                 href="challenge-submission"
+                 href="/cancellation-policy"
                  title="Submit a Challenge">
                 Submit a Challenge
               </a>


### PR DESCRIPTION
For https://github.com/csjoblom/hackforacause-website/issues/138

Done:

1. Created new page to outline cancellation policy.
2. Link all sign up and challenge submission links/buttons to this page.
3. Put yellow bar at top of home page with link to this page.
4. Removed link to schedule page.
5. Removed date and location from front page.

To test:
Click on links in menu bar, front page registration, announcement yellow bar.